### PR TITLE
add postman test collection to fetch sfu courses data

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 # relevant links
 * https://uwflow.com/
 * https://github.com/UWFlow
-* http://www.sfu.ca/outlines/help/api.html
-test
+
+### Test / Call SFU Courses API 
+http://www.sfu.ca/outlines/help/api.html
+1. Install the postman client
+2. Import the postman test collection (see "SFUCompass-SFU Courses API.postman_collection.json" in sfucompass folder)
+3. Go to a request & click "send" to fetch data
+4. Go to "Pre-request Script" to modify data of path variables
 

--- a/sfucompass/SFUCompass-SFU Courses API.postman_collection.json
+++ b/sfucompass/SFUCompass-SFU Courses API.postman_collection.json
@@ -1,0 +1,172 @@
+{
+	"info": {
+		"_postman_id": "0d59a3ff-244a-4c57-be6d-d16f390e8a02",
+		"name": "SFUCompass-SFU Courses API",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "single course section in year/yerm/department/courseNumber",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							"pm.globals.set(\"base_url\",\"http://www.sfu.ca/bin/wcm/course-outlines\")\r",
+							"pm.globals.set(\"year\",2023)\r",
+							"pm.globals.set(\"term\",\"spring\")\r",
+							"pm.globals.set(\"department\",\"cmpt\")\r",
+							"pm.globals.set(\"courseNumber\",276)\r",
+							"pm.globals.set(\"courseSection\",\"d100\")"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{base_url}}?{{year}}/{{term}}/{{department}}/{{courseNumber}}/{{courseSection}}",
+					"host": [
+						"{{base_url}}"
+					],
+					"query": [
+						{
+							"key": "{{year}}/{{term}}/{{department}}/{{courseNumber}}/{{courseSection}}",
+							"value": null
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "all sections of course in year/term/department",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							"pm.globals.set(\"base_url\",\"http://www.sfu.ca/bin/wcm/course-outlines\")\r",
+							"pm.globals.set(\"year\",2023)\r",
+							"pm.globals.set(\"term\",\"spring\")\r",
+							"pm.globals.set(\"department\",\"cmpt\")\r",
+							"pm.globals.set(\"courseNumber\",276)"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{base_url}}?{{year}}/{{term}}/{{department}}/{{courseNumber}}",
+					"host": [
+						"{{base_url}}"
+					],
+					"query": [
+						{
+							"key": "{{year}}/{{term}}/{{department}}/{{courseNumber}}",
+							"value": null
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "all courses in deptments in year/term",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							"pm.globals.set(\"base_url\",\"http://www.sfu.ca/bin/wcm/course-outlines\")\r",
+							"pm.globals.set(\"year\",2023)\r",
+							"pm.globals.set(\"term\",\"spring\")\r",
+							"pm.globals.set(\"department\",\"cmpt\")"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{base_url}}?{{year}}/{{term}}/{{department}}",
+					"host": [
+						"{{base_url}}"
+					],
+					"query": [
+						{
+							"key": "{{year}}/{{term}}/{{department}}",
+							"value": null
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "all course departments in year/term",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							"pm.globals.set(\"base_url\",\"http://www.sfu.ca/bin/wcm/course-outlines\")\r",
+							"pm.globals.set(\"year\",2023)\r",
+							"pm.globals.set(\"term\",\"spring\")"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{base_url}}?{{year}}/{{term}}",
+					"host": [
+						"{{base_url}}"
+					],
+					"query": [
+						{
+							"key": "{{year}}/{{term}}",
+							"value": null
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "all years (2014-present)",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							"pm.globals.set(\"base_url\",\"http://www.sfu.ca/bin/wcm/course-outlines\")"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{base_url}}",
+					"host": [
+						"{{base_url}}"
+					]
+				}
+			},
+			"response": []
+		}
+	]
+}


### PR DESCRIPTION
How to install Postman:
- Go to: https://www.postman.com/downloads/. Get the windows client or use the web client
- If you use the web client, I've made a postman account via the google account (see announcements)
https://web.postman.co/workspace/My-Workspace~a81219c0-1cfb-4098-84e8-4c98f74bf221/overview
- otherwise sign in through the windows client the same way through google


What I did:
- setup simple postman test collection with request hitting all endpoints available on SFU courses API. (It's very minimal)


Discoveries:
1. Course antirequisites is returned in a "notes" section, meaning we need to do some parsing to get just the course name/number + all other general antirequisites  
2. There will be missing fields returned when making a request for a course section. Will vary between courses requested
3. Courses data is organized like a folder: `year/term/department/courseNumber/courseSection`. Meaning, for example, to get *all* professors of a course's section you would need to call all specific course sections and fetch that data out of each response


How to test:
1. Import the postman test collection in the files or see instructions under "How to install Postman". The collection will be there already under the postman account I've setup
2. Send a request and inspect the data
